### PR TITLE
Require that SOPs be made available on public websites

### DIFF
--- a/2026/open_gov_data/sop_sharing
+++ b/2026/open_gov_data/sop_sharing
@@ -1,7 +1,0 @@
-RSA 91-A:1-a is amended to add
-	VII. “Standard Operating Procedures” or “SOP” means all formal policies and procedures that a Public agency or Public body disseminates to its personnel.
-
-RSA 91A:12 is added and states
-	I. All Standard Operating Procedures in use by all Public agencies and Public bodies must be made available for public inspection no later than 90 days after the enactment of this bill. Each Public body or Public agency that has a website, or makes use of another Public body’s or Public agency’s website, must make these documents prominently available on their website’s homepage.
-	II. Nothing in the section shall be construed to limit any Public agency’s or Public body’s duties to openness described elsewhere in this chapter.
-	III. Each document disseminated under this section must be available in a plain text format. Any Public agency or Public body is encouraged by this General Court to also make the documents available in other standardized and widely used formats.


### PR DESCRIPTION
This bill requires all public bodies and public agencies to post their SOPs on their website. Many police departments already do this as a matter of law. See https://www.lmpd.gov/882/LMPD-Public-Review-of-Policy for one such example. This is a "slippery slope" to restrict the ability of rank and file to violate People's rights. Once this is in effect people will be able to know the SOPs (like police officer should know). 

Once this is in effect for a year or two, we can look at what other areas of government information could/should be more widely available by default without going into the department.